### PR TITLE
Enable sbt to create eclipse project definition.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0")


### PR DESCRIPTION
It's a little change but makes life easier using the examples in Typesafe's Scala IDE.
