### PR TITLE
added foreign key defintion to the Users class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: scala

--- a/src/main/scala/com/typesafe/slick/examples/lifted/MultiDBCakeExample.scala
+++ b/src/main/scala/com/typesafe/slick/examples/lifted/MultiDBCakeExample.scala
@@ -36,6 +36,7 @@ trait UserComponent { this: Profile with PictureComponent => //requires Profile 
     def id = column[Option[Int]]("USER_ID", O.PrimaryKey, O.AutoInc)
     def name = column[String]("USER_NAME", O.NotNull)
     def pictureId = column[Int]("PIC_ID", O.NotNull)
+    def pictureKey = foreignKey("FK_USER_PICTURE", pictureId, pictures)(_.id.get)
     def * = (name, pictureId, id)
   }
   val users = TableQuery[Users]


### PR DESCRIPTION
To imrpove the slick documentation i added a foreign key defintion to the Users class
to show it it could be done in a multidbcake scenarion.

Added .travis.yml to activate travis build.

Related to this issue https://github.com/slick/slick-examples/issues/22 .
